### PR TITLE
Functionality to strip pcapNGs of metadata and turn them into PCAPs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,14 +6,14 @@ pcapml_SOURCES = include/dir/dir.hpp include/label/label.hpp include/label/label
 				 include/pcap/reader_pcap.hpp include/pcap/writer_pcap.hpp \
 				 include/pcapng/block_pcapng.hpp include/pcapng/reader_pcapng.hpp \
 				 include/pcapng/sorter_pcapng.hpp include/pcapng/splitter_pcapng.hpp \
-				 include/pcapng/writer_pcapng.hpp \
+				 include/pcapng/writer_pcapng.hpp include/pcapng/stripper_pcapng.hpp \
 				 include/sample/sample.hpp include/sample/sampler.hpp \
 				 include/util.hpp \
 				 src/dir/dir.cpp src/label/label.cpp src/label/labeler.cpp \
 				 src/pcap/reader_pcap.cpp src/pcap/writer_pcap.cpp \
 				 src/pcapng/block_pcapng.cpp src/pcapng/reader_pcapng.cpp \
 				 src/pcapng/sorter_pcapng.cpp src/pcapng/splitter_pcapng.cpp \
-				 src/pcapng/writer_pcapng.cpp \
+				 src/pcapng/writer_pcapng.cpp src/pcapng/stripper_pcapng.cpp \
 				 src/sample/sample.cpp src/sample/sampler.cpp \
 				 src/util.cpp src/pcapml.cpp
 

--- a/include/pcapng/stripper_pcapng.hpp
+++ b/include/pcapng/stripper_pcapng.hpp
@@ -16,15 +16,15 @@
 #include "writer_pcap.hpp"
 
 class Stripper : public PcapNGReader {
-  public:
+ public:
     bool process_block(Block *b, void *p);
     int strip_pcapng(char *infile, char *outfile);
-  private:
+ private:
     PcapWriter w;
-    uint16_t link_type=SENTINEL_LINKTYPE;
-    
+    uint16_t link_type = SENTINEL_LINKTYPE;
+
     int process_packet_block(Block *b);
-    int process_interface_header(Block *b, char *outfile); 
+    int process_interface_header(Block *b, char *outfile);
 };
 
 #endif  // INCLUDE_PCAPNG_STRIPPER_PCAPNG_HPP_

--- a/include/pcapng/stripper_pcapng.hpp
+++ b/include/pcapng/stripper_pcapng.hpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 nPrint
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#ifndef INCLUDE_PCAPNG_STRIPPER_PCAPNG_HPP_
+#define INCLUDE_PCAPNG_STRIPPER_PCAPNG_HPP_
+
+#define SENTINEL_LINKTYPE 999
+
+#include "util.hpp"
+#include "block_pcapng.hpp"
+#include "reader_pcapng.hpp"
+#include "writer_pcap.hpp"
+
+class Stripper : public PcapNGReader {
+  public:
+    bool process_block(Block *b, void *p);
+    int strip_pcapng(char *infile, char *outfile);
+  private:
+    PcapWriter w;
+    uint16_t link_type=SENTINEL_LINKTYPE;
+    
+    int process_packet_block(Block *b);
+    int process_interface_header(Block *b, char *outfile); 
+};
+
+#endif  // INCLUDE_PCAPNG_STRIPPER_PCAPNG_HPP_

--- a/src/pcapml.cpp
+++ b/src/pcapml.cpp
@@ -99,8 +99,8 @@ int main(int argc, char **argv) {
         fprintf(stderr, "No output configuration, exiting\n");
         exit(1);
     }
-    
-    if(arguments.pcapml != NULL) {
+
+    if (arguments.pcapml != NULL) {
         if (arguments.strip == true) {
             printf("stripping pcapNG file and turning into pcap\n");
             rv = stripper.strip_pcapng(arguments.pcapml, arguments.outfile);
@@ -126,8 +126,8 @@ int main(int argc, char **argv) {
         }
     }
 
-    if(arguments.labels != NULL) {
-        if(arguments.file_dir != NULL) {
+    if (arguments.labels != NULL) {
+        if (arguments.file_dir != NULL) {
             printf("Labeling directory: %s\n", arguments.file_dir);
             d.label_dir(std::string(arguments.file_dir),
                         std::string(arguments.labels),
@@ -150,6 +150,6 @@ int main(int argc, char **argv) {
             }
         }
     }
-    
+
     exit(0);
 }

--- a/src/pcapng/block_pcapng.cpp
+++ b/src/pcapng/block_pcapng.cpp
@@ -26,8 +26,8 @@ void Block::print(FILE *stream) {
     }
     fprintf(stream, "  }\n");
     fprintf(stream, "  FileWindow {\n");
-    fprintf(stream, "    start: %llu\n", fw.f_start);
-    fprintf(stream, "    end: %llu\n", fw.f_end);
+    fprintf(stream, "    start: %lu\n", fw.f_start);
+    fprintf(stream, "    end: %lu\n", fw.f_end);
     fprintf(stream, "  }\n");
     fprintf(stream, "}\n");
 }

--- a/src/pcapng/splitter_pcapng.cpp
+++ b/src/pcapng/splitter_pcapng.cpp
@@ -25,7 +25,7 @@ bool Splitter::process_block(Block *b, void *p) {
 
 bool Splitter::process_idb(Block *b) {
     InterfaceDescription *idb;
-
+    
     idb = (InterfaceDescription *) b->get_block_buf();
     cur_linktype = idb->link_type;
 

--- a/src/pcapng/stripper_pcapng.cpp
+++ b/src/pcapng/stripper_pcapng.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 nPrint
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "stripper_pcapng.hpp"
+
+bool Stripper::process_block(Block *b, void *p) {
+    uint32_t rv, block_type;
+
+    block_type = b->get_block_type();
+    
+    rv = 0;
+    printf("processing block\n");
+    if (block_type == INTERFACE_HEADER) {
+        rv = process_interface_header(b, (char *) p);
+    } else if(block_type == ENHANCED_PKT_HEADER) {
+        rv = process_packet_block(b);
+    }
+
+    if(rv == 0) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+int Stripper::process_interface_header(Block *b, char *outfile) {
+    uint32_t rv;
+    InterfaceDescription *idb;
+    
+    idb = (InterfaceDescription *) b->get_block_buf(); 
+    if(link_type == SENTINEL_LINKTYPE) {
+        link_type = idb->link_type;
+        rv = w.open_file(outfile, link_type);
+        if (rv != 0) {
+            fprintf(stderr, "Error opening pcap file, exiting\n");
+        }
+    }
+    else {
+        rv = 1;
+        fprintf(stderr, "PCAP does not support multiple linktypes in a single capture\n");
+    }
+
+    return rv;
+}
+
+int Stripper::process_packet_block(Block *b) {
+    pcap_pkthdr hdr;
+    EnhancedPacketBlock *epb;
+
+    epb = (EnhancedPacketBlock *) b->get_block_buf();
+    
+    hdr.caplen = epb->cap_len;
+    hdr.len = epb->og_len;
+    hdr.ts.tv_sec = epb->ts_high;
+    hdr.ts.tv_usec = epb->ts_low;
+    
+    w.write_packet(&hdr, b->get_data_buf());
+
+    return 0;
+}
+
+int Stripper::strip_pcapng(char *infile, char *outfile) {
+    Block *b;
+    uint32_t rv;
+    
+    writer_opened = false;
+    rv = open_pcapng(infile);
+    if (rv != 0) {
+        return 1;
+    }
+
+    while (1) {
+        b = read_block();
+        if (b == NULL) {
+            break;
+        }
+        process_block(b, (void *) outfile);
+        
+        delete b;
+    }
+
+    return 0;
+}

--- a/src/pcapng/stripper_pcapng.cpp
+++ b/src/pcapng/stripper_pcapng.cpp
@@ -10,17 +10,15 @@
 bool Stripper::process_block(Block *b, void *p) {
     uint32_t rv, block_type;
 
-    block_type = b->get_block_type();
-    
     rv = 0;
-    printf("processing block\n");
+    block_type = b->get_block_type();
     if (block_type == INTERFACE_HEADER) {
         rv = process_interface_header(b, (char *) p);
-    } else if(block_type == ENHANCED_PKT_HEADER) {
+    } else if (block_type == ENHANCED_PKT_HEADER) {
         rv = process_packet_block(b);
     }
 
-    if(rv == 0) {
+    if (rv == 0) {
         return true;
     } else {
         return false;
@@ -30,16 +28,15 @@ bool Stripper::process_block(Block *b, void *p) {
 int Stripper::process_interface_header(Block *b, char *outfile) {
     uint32_t rv;
     InterfaceDescription *idb;
-    
-    idb = (InterfaceDescription *) b->get_block_buf(); 
-    if(link_type == SENTINEL_LINKTYPE) {
+
+    idb = (InterfaceDescription *) b->get_block_buf();
+    if (link_type == SENTINEL_LINKTYPE) {
         link_type = idb->link_type;
         rv = w.open_file(outfile, link_type);
         if (rv != 0) {
             fprintf(stderr, "Error opening pcap file, exiting\n");
         }
-    }
-    else {
+    } else {
         rv = 1;
         fprintf(stderr, "PCAP does not support multiple linktypes in a single capture\n");
     }
@@ -52,12 +49,12 @@ int Stripper::process_packet_block(Block *b) {
     EnhancedPacketBlock *epb;
 
     epb = (EnhancedPacketBlock *) b->get_block_buf();
-    
+
     hdr.caplen = epb->cap_len;
     hdr.len = epb->og_len;
     hdr.ts.tv_sec = epb->ts_high;
     hdr.ts.tv_usec = epb->ts_low;
-    
+
     w.write_packet(&hdr, b->get_data_buf());
 
     return 0;
@@ -66,7 +63,7 @@ int Stripper::process_packet_block(Block *b) {
 int Stripper::strip_pcapng(char *infile, char *outfile) {
     Block *b;
     uint32_t rv;
-    
+
     rv = open_pcapng(infile);
     if (rv != 0) {
         return 1;
@@ -78,7 +75,7 @@ int Stripper::strip_pcapng(char *infile, char *outfile) {
             break;
         }
         process_block(b, (void *) outfile);
-        
+
         delete b;
     }
 

--- a/src/pcapng/stripper_pcapng.cpp
+++ b/src/pcapng/stripper_pcapng.cpp
@@ -67,7 +67,6 @@ int Stripper::strip_pcapng(char *infile, char *outfile) {
     Block *b;
     uint32_t rv;
     
-    writer_opened = false;
     rv = open_pcapng(infile);
     if (rv != 0) {
         return 1;

--- a/test/e2e/test.py
+++ b/test/e2e/test.py
@@ -1,0 +1,51 @@
+import os
+import shutil
+import argparse
+import subprocess
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('pcap')
+    parser.add_argument('metadata')
+    parser.add_argument('outdir')
+    parser.add_argument('-k', '--keep_files', action='store_true')
+    args = parser.parse_args()
+    
+    os.makedirs(args.outdir, exist_ok=True)
+
+    pcapng_test_file = os.path.join(args.outdir, 'test.pcapng')
+    pcap_test_file = os.path.join(args.outdir, 'test.pcap')
+    label_cmd = 'pcapml -P {0} -L {1} -W {2}'.format(args.pcap, args.metadata,
+                                                     pcapng_test_file)
+    proc = subprocess.run(label_cmd, shell=True)
+    
+    strip_cmd = 'pcapml -M {0} -p -W {1}'.format(pcapng_test_file, pcap_test_file)
+
+    proc = subprocess.run(strip_cmd, shell=True)
+
+    og_tcpdump = os.path.join(args.outdir, 'tcpdump_og.txt')
+    stripped_tcpdump = os.path.join(args.outdir, 'tcpdump_stripped.txt')
+
+    tcpdump_og_cmd = 'tcpdump -r {0} -nvv  > {1}'.format(args.pcap, og_tcpdump)
+    proc = subprocess.run(tcpdump_og_cmd, shell=True)
+
+    tcpdump_stripped_cmd = 'tcpdump -r {0} -nvv > {1}'.format(pcap_test_file, 
+                                                              stripped_tcpdump)
+    proc = subprocess.run(tcpdump_stripped_cmd, shell=True)
+
+    diff = 'diff tcpdump_og.txt tcpdump_stripped.txt -q -s -y'
+    proc = subprocess.run(diff, shell=True, stdout=subprocess.PIPE)
+    out = proc.stdout.decode('utf-8')
+    
+    if 'identical' in out:
+        print('PASSED')
+        print('  Original pcap and stripped pcapng are identical')
+        if not args.keep_files:
+            print('  Removing files from test, force keep with `-k`')
+            shutil.rmtree(args.outdir)
+    else:
+        print('FAILED')
+        print('  Original pcap and stripped pcapng differ')
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This commit gives us the functionality to do end to end testing on any PCAP or PCAPNG file that we've labeled by labeling a pcap file and being able to strip the comments, turning a pcapng file back into a pcap file.

PCAPNG files with more than 1 interface cannot be stripped into a single pcap due to the limitations of the PCAP capture format. no plan to deal with that as these pcapNG files can be split into multiple pcaps using pcapML already.