### PR TITLE
Pcap_next_ex and stats

### DIFF
--- a/include/label/labeler.hpp
+++ b/include/label/labeler.hpp
@@ -27,10 +27,14 @@ static volatile int stop = 0;
 
 class PcapMLLabeler {
  public:
+    void print_stats(FILE *stream);
     bool label_pcap(char *label_file, char *pcap, char *outfile,
-                    bool infile_is_device);
+                    bool infile_is_device, bool print_stats);
  private:
     std::vector<Label *> labels;
+    uint64_t packets_matched = 0;
+    uint64_t packets_received = 0;
+    
     bool load_labels(char *label_file, pcap_t *handle = NULL);
 };
 

--- a/include/label/labeler.hpp
+++ b/include/label/labeler.hpp
@@ -34,7 +34,7 @@ class PcapMLLabeler {
     std::vector<Label *> labels;
     uint64_t packets_matched = 0;
     uint64_t packets_received = 0;
-    
+
     bool load_labels(char *label_file, pcap_t *handle = NULL);
 };
 

--- a/include/pcap/reader_pcap.hpp
+++ b/include/pcap/reader_pcap.hpp
@@ -14,6 +14,10 @@
 #include <net/ethernet.h>
 #endif
 
+#define PCAP_NEXT_EX_EOF -2
+#define PCAP_NEXT_EX_ERR -1
+#define PCAP_NEXT_EX_NOP 0
+
 #define LINUX_COOKED_HEADER_SIZE 16
 
 #include <pcap.h>
@@ -26,6 +30,7 @@ class PcapReader {
     uint16_t get_linktype();
     int open_live(char *devce);
     int open_file(char *infile);
+    void print_stats(FILE *stream);
     pcap_packet_info *get_next_packet();
  private:
     pcap_t *f = NULL;

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -20,8 +20,9 @@
 #include "block_pcapng.hpp"
 
 struct pcap_packet_info {
-    struct pcap_pkthdr hdr;
+    struct pcap_pkthdr *hdr;
     const uint8_t *buf;
+    int32_t pcap_next_rv;
 };
 
 bool check_file_exists(char *f);

--- a/src/label/label.cpp
+++ b/src/label/label.cpp
@@ -48,7 +48,6 @@ bool Label::set_info(std::string label, std::string bpf_string_filter,
         }
     }
 
-
     /* build longid, hashid, and comment string for file */
     unhashed_sample_id = label + "_" + bpf_string_filter + "_" + std::to_string(ts_start) + "_" + std::to_string(ts_end);
     sample_id = std::to_string(str_hash(unhashed_sample_id));
@@ -65,9 +64,9 @@ bool Label::match_packet(pcap_packet_info *pi) {
     int bpf_match;
     bool ts_match;
 
-    bpf_match = pcap_offline_filter(bpf_pcap_filter, &(pi->hdr), pi->buf);
+    bpf_match = pcap_offline_filter(bpf_pcap_filter, pi->hdr, pi->buf);
 
-    pkt_ts = pi->hdr.ts.tv_sec;
+    pkt_ts = pi->hdr->ts.tv_sec;
     ts_match = ((ts_start <= pkt_ts) && (pkt_ts <= ts_end)) ? true : false;
 
     return bpf_match && ts_match;

--- a/src/label/labeler.cpp
+++ b/src/label/labeler.cpp
@@ -86,7 +86,7 @@ bool PcapMLLabeler::label_pcap(char *label_file, char *infile, char *outfile,
     /* register signal now */
     signal(SIGINT, sig_handler);
 
-    
+
     while (1) {
         if (stop) {
             break;
@@ -94,10 +94,10 @@ bool PcapMLLabeler::label_pcap(char *label_file, char *infile, char *outfile,
         pi = r.get_next_packet();
         if (pi == NULL) {
             break;
-        }
-        else if (pi->pcap_next_rv == PCAP_NEXT_EX_NOP) {
+        } else if (pi->pcap_next_rv == PCAP_NEXT_EX_NOP) {
             continue;
         }
+
         for (vit = labels.begin(); vit != labels.end(); vit++) {
             /* match here */
             if ((*vit)->match_packet(pi)) {

--- a/src/label/labeler.cpp
+++ b/src/label/labeler.cpp
@@ -57,9 +57,8 @@ void sig_handler(int useless) {
 }
 
 bool PcapMLLabeler::label_pcap(char *label_file, char *infile, char *outfile,
-                               bool infile_is_device) {
+                               bool infile_is_device, bool stats_out) {
     uint16_t linktype;
-    uint64_t matched, total;
     std::vector<Label *>::iterator vit;
     PcapNGWriter w;
     PcapReader r;
@@ -87,8 +86,7 @@ bool PcapMLLabeler::label_pcap(char *label_file, char *infile, char *outfile,
     /* register signal now */
     signal(SIGINT, sig_handler);
 
-    total = 0;
-    matched = 0;
+    
     while (1) {
         if (stop) {
             break;
@@ -97,17 +95,30 @@ bool PcapMLLabeler::label_pcap(char *label_file, char *infile, char *outfile,
         if (pi == NULL) {
             break;
         }
+        else if (pi->pcap_next_rv == PCAP_NEXT_EX_NOP) {
+            continue;
+        }
         for (vit = labels.begin(); vit != labels.end(); vit++) {
             /* match here */
             if ((*vit)->match_packet(pi)) {
                 w.write_epb_from_pcap_pkt(pi, (*vit)->get_comment_string());
-                matched++;
+                packets_matched++;
                 break;
             }
         }
-        total++;
+        delete pi;
+        packets_received++;
+    }
+    if (stats_out) {
+        print_stats(stdout);
+        r.print_stats(stdout);
     }
     w.close_file();
 
     return true;
+}
+
+void PcapMLLabeler::print_stats(FILE *stream) {
+    fprintf(stream, "Labeler: packets received: %ld\n", packets_received);
+    fprintf(stream, "Labeler: packets matched:  %ld\n", packets_matched);
 }

--- a/src/pcap/reader_pcap.cpp
+++ b/src/pcap/reader_pcap.cpp
@@ -56,15 +56,15 @@ pcap_packet_info *PcapReader::get_next_packet() {
     pcap_pkthdr *hdr;
     const u_int8_t *buf;
     pcap_packet_info *pi;
-    
+
     rv = pcap_next_ex(f, &hdr, &buf);
-    if(rv == PCAP_NEXT_EX_EOF) {
+    if (rv == PCAP_NEXT_EX_EOF) {
         return NULL;
     } else if (rv == PCAP_NEXT_EX_ERR) {
         pcap_perror(f, "Error while reading pcap: ");
         exit(99);
     }
-    
+
     pi = new pcap_packet_info;
     pi->hdr = hdr;
     pi->buf = buf;
@@ -83,8 +83,8 @@ void PcapReader::print_stats(FILE *stream) {
 
     rv = pcap_stats(f, &ps);
     /* return as PCAP stats do not work on non-live captures */
-    if(rv != 0) return;
-    
+    if (rv != 0) return;
+
     fprintf(stream, "PCAP: packets received: %d\n", ps.ps_recv);
     fprintf(stream, "PCAP: packet buffer drops: %d\n", ps.ps_drop);
     fprintf(stream, "PCAP: packet interface drops: %d\n", ps.ps_ifdrop);

--- a/src/pcapml.cpp
+++ b/src/pcapml.cpp
@@ -28,6 +28,7 @@ static struct argp_option options[] = {
     {"outdir", 'O', "FILE", 0, "output directory for split pcaps"},
     {"label_file", 'L', "FILE", 0, "labels for packets"},
     {"sort", 's', 0, 0, "sort pcapng by sampleid -> time"},
+    {"stats", 't', 0, 0, "print stats when finished"},
     {"strip", 'p', 0, 0, "strip pcapng of metadata and transform to pcap"},
     {"device", 'd', "STRING", 0, "device (if not default) to capture traffic from"},
     {0}};
@@ -35,6 +36,7 @@ static struct argp_option options[] = {
 struct arguments {
     bool sort = false;
     bool strip = false;
+    bool stats = false;
     char *pcap = NULL;
     char *outfile = NULL;
     char *labels = NULL;
@@ -74,6 +76,9 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
         break;
     case 'd':
         arguments->device = arg;
+        break;
+    case 't':
+        arguments->stats = true;
         break;
     default:
         return ARGP_ERR_UNKNOWN;
@@ -135,7 +140,7 @@ int main(int argc, char **argv) {
         } else if (arguments.pcap != NULL) {
             printf("Labeling PCAP: %s\n", arguments.pcap);
             rv = labeler.label_pcap(arguments.labels, arguments.pcap,
-                                    arguments.outfile, false);
+                                    arguments.outfile, false, arguments.stats);
             if (rv == false) {
                 printf("Failure while parsing pcap\n");
                 exit(4);
@@ -143,7 +148,7 @@ int main(int argc, char **argv) {
         } else {
             printf("processing live traffic\n");
             rv = labeler.label_pcap(arguments.labels, arguments.device,
-                                    arguments.outfile, true);
+                                    arguments.outfile, true, arguments.stats);
             if (rv == false) {
                 printf("Error parsing live traffic, exiting\n");
                 exit(5);

--- a/src/pcapng/writer_pcapng.cpp
+++ b/src/pcapng/writer_pcapng.cpp
@@ -101,10 +101,10 @@ int PcapNGWriter::write_epb_from_pcap_pkt(pcap_packet_info *p, std::string comme
     EnhancedPacketBlock epb;
 
     epb.interface_id = 0;
-    epb.ts_high = p->hdr.ts.tv_sec;
-    epb.ts_low = p->hdr.ts.tv_usec;
-    epb.cap_len = p->hdr.caplen;
-    epb.og_len = p->hdr.len;
+    epb.ts_high = p->hdr->ts.tv_sec;
+    epb.ts_low = p->hdr->ts.tv_usec;
+    epb.cap_len = p->hdr->caplen;
+    epb.og_len = p->hdr->len;
 
     /* Base header + EPB header + packet + packet padding + comment 
      * + comment padding + option headers * 2 (end of options & comment)


### PR DESCRIPTION
* Changed `pcap_next` call to `pcap_next_ex` so we can disambiguate the return value for live capture timeouts
* Added optional stats output at the end so we can easily calculate how many packets matched the filters and if we dropped packets during live capture.